### PR TITLE
Bug/remove initial slash

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -2,3 +2,4 @@
 - ADD Ping service for the router.
 - FIX Problems with compatibility with other LWM2M implementations.
 - ADD Update connection in the command line tool.
+- FIX Remove initial slash from Location-path to conform to COAP standard.

--- a/lib/services/server/registration.js
+++ b/lib/services/server/registration.js
@@ -44,7 +44,7 @@ function endRegistration(req, res) {
             res.code = error.code;
             res.end(error.name);
         } else {
-            var root = (config.baseRoot) ? config.baseRoot + '/': '/';
+            var root = (config.baseRoot) ? config.baseRoot + '/': '';
 
             logger.debug(context, 'Registration request ended successfully');
             res.code = '2.01';

--- a/test/unit/client/client-device-managment-test.js
+++ b/test/unit/client/client-device-managment-test.js
@@ -41,7 +41,7 @@ describe('Client-side device management', function() {
 
             lwm2mClient.register('localhost', config.server.port, null, 'testEndpoint', function (error, result) {
                 deviceInformation = result;
-                deviceId = deviceInformation.location.split('/')[2];
+                deviceId = deviceInformation.location.split('/')[1];
                 lwm2mClient.registry.create('/3/6', done);
             });
         });

--- a/test/unit/client/client-information-management-test.js
+++ b/test/unit/client/client-information-management-test.js
@@ -45,7 +45,7 @@ describe('Client-side information management', function() {
 
             lwm2mClient.register('localhost', config.server.port, null, 'testEndpoint', function (error, result) {
                 deviceInformation = result;
-                deviceId = deviceInformation.location.split('/')[2];
+                deviceId = deviceInformation.location.split('/')[1];
                 lwm2mClient.registry.create('/3/6', done);
             });
         });

--- a/test/unit/server/client-registration-test.js
+++ b/test/unit/server/client-registration-test.js
@@ -142,7 +142,7 @@ describe('Client registration interface', function() {
             req.on('response', function(res) {
                 res.options.length.should.equal(1);
                 res.options[0].name.should.equal('Location-Path');
-                res.options[0].value.should.match(/\/rd\/.*/);
+                res.options[0].value.should.match(/rd\/.*/);
                 done();
             });
         });

--- a/test/unit/server/device-management-test.js
+++ b/test/unit/server/device-management-test.js
@@ -81,7 +81,7 @@ describe('Device management interface' , function() {
                 res.end('The Read content');
             });
 
-            libLwm2m2.discover(deviceLocation.split('/')[2], '6', '2', '5', function (error, result) {
+            libLwm2m2.discover(deviceLocation.split('/')[1], '6', '2', '5', function (error, result) {
                 should.not.exist(error);
                 should.exist(result);
                 result.should.equal('The Read content');
@@ -104,7 +104,7 @@ describe('Device management interface' , function() {
                 res.end('The content');
             });
 
-            libLwm2m2.write(deviceLocation.split('/')[2], '6', '2', '5', 'The value', function (error) {
+            libLwm2m2.write(deviceLocation.split('/')[1], '6', '2', '5', 'The value', function (error) {
                 should.not.exist(error);
                 data.should.equal('The value');
                 done();
@@ -129,7 +129,7 @@ describe('Device management interface' , function() {
                 res.end('</6/2/5>;pmin=10;pmax=60;lt=42.2');
             });
 
-            libLwm2m2.discover(deviceLocation.split('/')[2], '6', '2', '5', function (error, result) {
+            libLwm2m2.discover(deviceLocation.split('/')[1], '6', '2', '5', function (error, result) {
                 should.not.exist(error);
                 should.exist(result);
                 result.should.equal('</6/2/5>;pmin=10;pmax=60;lt=42.2');
@@ -149,7 +149,7 @@ describe('Device management interface' , function() {
                 res.end('</6/2>;pmin=10;pmax=60;lt=42.2,</6/2/1>');
             });
 
-            libLwm2m2.discover(deviceLocation.split('/')[2], '6', '2', function (error, result) {
+            libLwm2m2.discover(deviceLocation.split('/')[1], '6', '2', function (error, result) {
                 should.not.exist(error);
                 should.exist(result);
                 result.should.equal('</6/2>;pmin=10;pmax=60;lt=42.2,</6/2/1>');
@@ -169,7 +169,7 @@ describe('Device management interface' , function() {
                 res.end('</6>;pmin=10;pmax=60;lt=42.2,</6//1>');
             });
 
-            libLwm2m2.discover(deviceLocation.split('/')[2], '6', function (error, result) {
+            libLwm2m2.discover(deviceLocation.split('/')[1], '6', function (error, result) {
                 should.not.exist(error);
                 should.exist(result);
                 result.should.equal('</6>;pmin=10;pmax=60;lt=42.2,</6//1>');
@@ -209,7 +209,7 @@ describe('Device management interface' , function() {
                 res.end('The content');
             });
 
-            libLwm2m2.writeAttributes(deviceLocation.split('/')[2], '6', '2', '5', attributes, function (error) {
+            libLwm2m2.writeAttributes(deviceLocation.split('/')[1], '6', '2', '5', attributes, function (error) {
                 should.not.exist(error);
                 requestSent.should.equal(true);
                 done();
@@ -238,7 +238,7 @@ describe('Device management interface' , function() {
                     res.end('The content');
                 });
 
-                libLwm2m2.writeAttributes(deviceLocation.split('/')[2], '6', '2', '5', attributes, function (error) {
+                libLwm2m2.writeAttributes(deviceLocation.split('/')[1], '6', '2', '5', attributes, function (error) {
                     should.exist(error);
                     error.name.should.equal('UNRECOGNIZED_ATTRIBUTE');
                     requestSent.should.equal(false);
@@ -259,7 +259,7 @@ describe('Device management interface' , function() {
                 res.end('The Read content');
             });
 
-            libLwm2m2.create(deviceLocation.split('/')[2], '6', '3', function (error) {
+            libLwm2m2.create(deviceLocation.split('/')[1], '6', '3', function (error) {
                 should.not.exist(error);
                 requestArrived.should.equal(true);
                 done();

--- a/test/unit/server/information-reporting-test.js
+++ b/test/unit/server/information-reporting-test.js
@@ -93,7 +93,7 @@ describe('Information reporting interface', function() {
                     res.end('The Read content');
                 });
 
-                libLwm2m2.observe(deviceLocation.split('/')[2], '6', '2', '5', emptyHandler, function (error, result) {
+                libLwm2m2.observe(deviceLocation.split('/')[1], '6', '2', '5', emptyHandler, function (error, result) {
                     should.not.exist(error);
                     should.exist(result);
                     result.should.equal('The Read content');
@@ -107,14 +107,14 @@ describe('Information reporting interface', function() {
                 res.end('The Read content');
             });
 
-            libLwm2m2.observe(deviceLocation.split('/')[2], '6', '2', '5', emptyHandler, function (error, result) {
+            libLwm2m2.observe(deviceLocation.split('/')[1], '6', '2', '5', emptyHandler, function (error, result) {
                 should.not.exist(error);
 
                 libLwm2m2.listObservers(function (error, result) {
                     should.not.exist(error);
                     result.length.should.equal(1);
                     result[0].resource.should.equal('/6/2/5');
-                    result[0].deviceId.should.equal(deviceLocation.split('/')[2]);
+                    result[0].deviceId.should.equal(deviceLocation.split('/')[1]);
                     done();
                 });
             });
@@ -144,7 +144,7 @@ describe('Information reporting interface', function() {
                 }
             }
 
-            libLwm2m2.observe(deviceLocation.split('/')[2], '6', '2', '5', userHandler, function (error, result) {
+            libLwm2m2.observe(deviceLocation.split('/')[1], '6', '2', '5', userHandler, function (error, result) {
                 should.not.exist(error);
             });
         });
@@ -178,7 +178,7 @@ describe('Information reporting interface', function() {
                 handlerInvokedTimes++;
 
                 if (handlerInvokedTimes === 1) {
-                    libLwm2m2.cancelObserver(deviceLocation.split('/')[2], '6', '2', '5', function () {
+                    libLwm2m2.cancelObserver(deviceLocation.split('/')[1], '6', '2', '5', function () {
                         setTimeout(function () {
                             handlerInvokedTimes.should.equal(1);
                             done();
@@ -187,7 +187,7 @@ describe('Information reporting interface', function() {
                 }
             }
 
-            libLwm2m2.observe(deviceLocation.split('/')[2], '6', '2', '5', userHandler, function (error, result) {
+            libLwm2m2.observe(deviceLocation.split('/')[1], '6', '2', '5', userHandler, function (error, result) {
                 should.not.exist(error);
             });
         });
@@ -199,10 +199,10 @@ describe('Information reporting interface', function() {
                 handlerInvokedTimes++;
             }
 
-            libLwm2m2.observe(deviceLocation.split('/')[2], '6', '2', '5', userHandler, function (error, result) {
+            libLwm2m2.observe(deviceLocation.split('/')[1], '6', '2', '5', userHandler, function (error, result) {
                 should.not.exist(error);
 
-                libLwm2m2.cancelObserver(deviceLocation.split('/')[2], '6', '2', '5', function () {
+                libLwm2m2.cancelObserver(deviceLocation.split('/')[1], '6', '2', '5', function () {
                         libLwm2m2.listObservers(function (error, result) {
                             should.not.exist(error);
                             result.length.should.equal(0);


### PR DESCRIPTION
Remove initial slash from returned Location-path to conform to COAP Standard (Location-path is supposed to reflect a relative URI, not an absolute one).