### PR TITLE
FIX Client handler after connection update

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -3,3 +3,4 @@
 - Add Command-node module for the command-line interpreters.
 - Fix MongoDB did not recover information at starting (#38).
 - Fix command line break when executing command before starting the server (#47).
+- FIX Client handler after connection update (#51)

--- a/bin/iotagent-lwm2m-client.js
+++ b/bin/iotagent-lwm2m-client.js
@@ -164,10 +164,12 @@ function disconnect(command) {
 
 function updateConnection(command) {
     if (globalDeviceInfo) {
-        lwm2mClient.update(globalDeviceInfo, function(error) {
+        lwm2mClient.update(globalDeviceInfo, function(error, deviceInfo) {
             if (error) {
                 clUtils.handleError(error);
             } else {
+                globalDeviceInfo = deviceInfo;
+                setHandlers(deviceInfo);
                 console.log('\Information updated:\n--------------------------------\n');
                 clUtils.prompt();
             }


### PR DESCRIPTION
You can't exec commands from server to the client after connection update. This will fix it.