### PR TITLE
fix content-format handling

### DIFF
--- a/lib/services/server/deviceManagement.js
+++ b/lib/services/server/deviceManagement.js
@@ -228,7 +228,7 @@ function discover(deviceId, objectType, objectId, resourceId, fullCallback) {
             proxyUri: 'coap://' + obj.address + ':' + obj.port,
             pathname: pathname,
             options: {
-                'Accept': 'application/link-format'
+                'Content-Format': 'application/link-format'
             }
         };
 


### PR DESCRIPTION
The name of the CoAP option seemed to be wrong, changed to 'Content-Format'.