### PR TITLE
Fix IPv6 address format for node-coap

### DIFF
--- a/lib/services/server/deviceManagement.js
+++ b/lib/services/server/deviceManagement.js
@@ -228,7 +228,7 @@ function discover(deviceId, objectType, objectId, resourceId, fullCallback) {
             proxyUri: 'coap://' + obj.address + ':' + obj.port,
             pathname: pathname,
             options: {
-                'Accept': 'application/link-format'
+                'Content-Format': 'application/link-format'
             }
         };
 

--- a/lib/services/server/registration.js
+++ b/lib/services/server/registration.js
@@ -75,12 +75,14 @@ function storeDevice(queryParams, req, callback) {
     var device = {
         name: queryParams.ep,
         lifetime: queryParams.lt,
-        address: req.rsinfo.address,
+        address: (req.rsinfo.family === 'IPv6') ? '[' + req.rsinfo.address +']' : req.rsinfo.address,
         port: req.rsinfo.port,
         creationDate: new Date()
     };
 
     logger.debug(context, 'Storing the following device in the db:\n%s', JSON.stringify(device, null, 4));
+
+
 
     device.path = req.urlObj.pathname;
 

--- a/lib/services/server/updateRegistration.js
+++ b/lib/services/server/updateRegistration.js
@@ -62,7 +62,11 @@ function updateRegister(req, queryParams, obj, callback) {
     logger.debug(context, 'Updating device register with lifetime [%s] and address [%s].',
         queryParams.lt, req.rsinfo.address);
     obj.lifetime = queryParams.lt || obj.lifetime;
-    obj.address = req.rsinfo.address;
+    if (req.rsinfo.family === 'IPv6') {
+        obj.address = '[' + req.rsinfo.address + ']';
+    } else {
+        obj.address = req.rsinfo.address;
+    }
     obj.port = req.rsinfo.port;
     obj.creationDate = new Date();
     callback(null, obj);


### PR DESCRIPTION
node-coap requires IPv6 addresses to be wrapped in '[' ']' otherwise it
    throws name resolution exception