### PR TITLE
Fix coapUtils.extractQueryParams when empty query.

### DIFF
--- a/lib/services/coapUtils.js
+++ b/lib/services/coapUtils.js
@@ -97,7 +97,7 @@ function extractQueryParams(req, callback) {
 
         queryParams = req.urlObj.query.split('&');
     } else {
-        queryParams = {};
+        queryParams = [];
     }
 
     if (callback) {


### PR DESCRIPTION
Simple oneliner fix.