### PR TITLE
FIX Wrong type of object in queryParams

### DIFF
--- a/lib/services/coapUtils.js
+++ b/lib/services/coapUtils.js
@@ -97,7 +97,7 @@ function extractQueryParams(req, callback) {
 
         queryParams = req.urlObj.query.split('&');
     } else {
-        queryParams = {};
+        queryParams = [];
     }
 
     if (callback) {


### PR DESCRIPTION
Replicates #76 pointing to `develop`