### PR TITLE
Fix coap querystring

### DIFF
--- a/lib/services/server/deviceManagement.js
+++ b/lib/services/server/deviceManagement.js
@@ -149,18 +149,20 @@ function execute(deviceId, objectType, objectId, resourceId, value, callback) {
 function writeAttributes(deviceId, objectType, objectId, resourceId, attributes, callback) {
     function createQueryParams(innerCb) {
         var validAttributes = ['pmin', 'pmax', 'gt', 'lt', 'st', 'cancel'],
-            result = '?',
+            result = [],
             errorList = [];
 
         for (var i in attributes) {
             if (attributes.hasOwnProperty(i)) {
                 if (validAttributes.indexOf(i) >= 0) {
-                    result += i + '=' + attributes[i] + '&';
+                    result.push(i + '=' + attributes[i]);
                 } else {
                     errorList.push(i);
                 }
             }
         }
+
+        result = result.join('&');
 
         if (errorList.length !== 0) {
             innerCb(new errors.UnsupportedAttributes(errorList));
@@ -175,14 +177,15 @@ function writeAttributes(deviceId, objectType, objectId, resourceId, attributes,
             port: config.port,
             proxyUri: 'coap://' + (config.ipProtocol === 'udp6' ? '['+data[0].address+']' : data[0].address) +
               ':' + data[0].port,
-            method: 'PUT'
+            method: 'PUT',
+            query: data[1]
         };
         if (isPresent(objectType, objectId, resourceId)) {
-            request.pathname = '/' + objectType + '/' + objectId + '/' + resourceId + data[1];
+            request.pathname = '/' + objectType + '/' + objectId + '/' + resourceId;
         } else if (isPresent(objectType, objectId)) {
-            request.pathname = '/' + objectType + '/' + objectId + data[1];
+            request.pathname = '/' + objectType + '/' + objectId;
         } else {
-            request.pathname = '/' + objectType + data[1];
+            request.pathname = '/' + objectType;
         }
 
         innerCb(null, request);


### PR DESCRIPTION
As per node-coap documentation, `pathname` should not include query string. This fixes `writeAttributes` method not working with LWM2M clients e.g. Eclipse Wakaama