### PR TITLE
Add support for objects 1/2

### DIFF
--- a/lib/services/object/device.js
+++ b/lib/services/object/device.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 'use strict';

--- a/lib/services/object/device.js
+++ b/lib/services/object/device.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ *
+ * This file is part of lwm2m-node-lib
+ *
+ * lwm2m-node-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * lwm2m-node-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with lwm2m-node-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+'use strict';
+
+var Schema = require('./schema');
+
+// add remaining optional resources for completeness
+module.exports = new Schema('Device', {
+  manufacturer: { type: String, id: 0 },
+  deviceType:   { type: String, id: 17 },
+  modelNumber:  { type: String, id: 1 },
+  serialNumber: { type: String, id: 2 },
+  hardwareVer:  { type: String, id: 18 },
+  firmwareVer:  { type: String, id: 3 },
+  softwareVer:  { type: String, id: 19 },
+  powerSrcs:    [{ type: Number, id: 6 }],
+  srcVoltage:   [{ type: Number, id: 7 }],
+  srcCurrent:   [{ type: Number, id: 8 }],
+  batteryLevel: { type: Number, id: 9 },
+  memoryFree:   { type: Number, id: 10 },
+  errorCode:    [{ type: Number, id: 11 }],
+  currentTime:  { type: Number, id: 13 },
+  utcOffset:    { type: String, id: 14 },
+  timeZone:     { type: String, id: 15 }
+});
+

--- a/lib/services/object/index.js
+++ b/lib/services/object/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 exports.Schema = require('./schema');

--- a/lib/services/object/index.js
+++ b/lib/services/object/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
  *
  * This file is part of lwm2m-node-lib
  *
@@ -21,13 +21,9 @@
  * please contact with::[contacto@tid.es]
  */
 
-'use strict';
-
-exports.server = require('./lwm2m-server');
-exports.client = require('./lwm2m-client');
-
-var object = require('./services/object');
-exports.Schema = object.Schema; // constructor
-exports.schemas = object.schemas; // OMA LWM2M Objects
-
-
+exports.Schema = require('./schema');
+exports.schemas = {
+  device: require('./device'),
+  security: require('./security'),
+  server: require('./server')
+};

--- a/lib/services/object/schema.js
+++ b/lib/services/object/schema.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 'use strict';

--- a/lib/services/object/schema.js
+++ b/lib/services/object/schema.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ *
+ * This file is part of lwm2m-node-lib
+ *
+ * lwm2m-node-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * lwm2m-node-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with lwm2m-node-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+'use strict';
+
+function matches(val, type) {
+  function typeOf(val) {
+    return Object.prototype.toString.call(val).slice(8, -1);
+  }
+
+  if (type === 'Buffer') {
+    return Buffer.isBuffer(val);
+  }
+
+  if (!Array.isArray(type)) {
+    return type === typeOf(val);
+  }
+
+  if (Array.isArray(val)) {
+    return matches(val[0], type[0]);
+  }
+
+  return false;
+}
+
+function isObject(o) {
+  return Object.prototype.toString.call(o) === '[object Object]';
+}
+
+function validResourceType(type) {
+  return ['String', 'Number', 'Boolean', 'Buffer'].indexOf(type) > -1;
+}
+
+function validateProps(type, id) {
+  return validResourceType(type) && typeof id === 'number';
+}
+
+
+
+function Schema(name, resources) {
+  this.name = name;
+  this.resources = {};
+  this.resourceNames = {};
+
+  for (var key in resources) {
+    if (resources.hasOwnProperty(key)) {
+
+      var ok = false,
+          res = resources[key];
+
+      if (isObject(res)) {
+        ok = validateProps(res.type.name, res.id);
+
+        this.resources[key] = {
+          type: res.type.name,
+          id: res.id,
+          required: res.required || false
+        };
+
+        this.resourceNames[res.id] = key;
+      }
+
+      if (Array.isArray(res)) {
+        var type = res[0].type,
+            id = res[0].id,
+            required = res[0].required || false;
+
+        ok = validateProps(type.name, id);
+
+        this.resources[key] = { 
+          type: [type.name], 
+          id: id, 
+          required: required || false
+        };
+
+        this.resourceNames[id] = key;
+      }
+
+      if (!ok) {
+        throw new TypeError('Invalid resource `' + key + '`');
+      }
+    }
+  }
+}
+
+Schema.prototype.resourceNameById = function(id) {
+  return this.resourceNames[id];
+};
+
+Schema.prototype.validateResource = function(key, val) {
+  var name = key;
+
+  if (!this.resources[key]) {
+    name = this.resourceNameById(key);
+  }
+
+  if (!name) {
+    throw new TypeError('Invalid resource `' + key + '`');
+  }
+
+  var type = this.resources[name].type;
+  var ok = matches(val, type);
+
+  if (!ok) {
+    throw new TypeError('Invalid type for `' + key + '`');
+  }
+};
+
+Schema.prototype.validate = function(obj) {
+  var keys = Object.keys(this.resources);
+
+  for (var i = 0; i < keys.length; ++i) {
+    var key = keys[i],
+        type = this.resources[key].type,
+        id = this.resources[key].id,
+        required = this.resources[key].required,
+        val, ok;
+
+    val = obj[key] === undefined ? obj[id] : obj[key];
+    ok = matches(val, type);
+
+    if (val !== undefined && !ok) {
+      throw new TypeError('Invalid resource `' + key + '`');
+    }
+
+    if (required && !ok) {
+      throw new TypeError('Missing resource `' + key + '`');
+    }
+  }
+};
+
+module.exports = Schema;

--- a/lib/services/object/security.js
+++ b/lib/services/object/security.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 'use strict';

--- a/lib/services/object/security.js
+++ b/lib/services/object/security.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
  *
  * This file is part of lwm2m-node-lib
  *
@@ -23,11 +23,16 @@
 
 'use strict';
 
-exports.server = require('./lwm2m-server');
-exports.client = require('./lwm2m-client');
+var Schema = require('./schema');
 
-var object = require('./services/object');
-exports.Schema = object.Schema; // constructor
-exports.schemas = object.schemas; // OMA LWM2M Objects
-
-
+// note: these are only the mandatory resources
+// add optional resources for completeness
+module.exports = new Schema('LWM2M Security', {
+  uri:        { type: String, id: 0, required: true },
+  bootstrap:  { type: Boolean, id: 1, required: true },
+  mode:       { type: Number, id: 2, required: true },
+  clientCert: { type: Buffer, id: 3, required: true },
+  serverId:   { type: Number, id: 10, required: true },
+  serverCert: { type: Buffer, id: 4, required: true },
+  secret:     { type: Buffer, id: 5, required: true },
+});

--- a/lib/services/object/senml.js
+++ b/lib/services/object/senml.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 'use strict';

--- a/lib/services/object/senml.js
+++ b/lib/services/object/senml.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ *
+ * This file is part of lwm2m-node-lib
+ *
+ * lwm2m-node-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * lwm2m-node-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with lwm2m-node-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+'use strict';
+
+var logger = require('logops'),
+    context = {
+        op: 'LWM2MLib.BootstrapServer'
+    };
+
+function serializeToString(obj, schema) {
+  var result = { e: [] },
+      keys = Object.keys(obj),
+      res = schema.resources;
+
+  function append(arr, key, value) {
+    var types = {
+      String: function() {
+        arr.push({ n: key, sv: value });
+      },
+      Number: function() {
+        arr.push({ n: key, v: value });
+      },
+      Boolean: function() {
+        arr.push({ n: key, bv: value });
+      },
+      Buffer: function() {
+        arr.push({ 
+          n: key, 
+          sv: value.toString('base64') 
+        });
+      },
+      Array: function() {
+        for (var i = 0; i < value.length; i++) {
+          append(arr, key + '/' + i, value[i]);
+        }
+      }
+    };
+
+    function skip () {
+      logger.warn(context, 'Skipping resource with invalid type %s', typeof value);
+    }
+
+    var type = Object.prototype.toString.call(value).slice(8, -1);
+
+    if (Buffer.isBuffer(value)) {
+      type = Buffer.name;
+    }
+
+    (types[type] || skip)();
+    
+    return arr;
+  }
+
+
+  if (keys.length === 1) { // single resource
+    schema.validateResource(keys[0], obj[keys[0]]);
+  } else {                // whole object
+    schema.validate(obj);
+  }
+
+  for (var i = 0; i < keys.length; ++i) {
+    var key = keys[i],
+        id = res[key] ? res[key].id : key;
+
+    append(result.e, String(id), obj[key]);
+  }
+
+  return JSON.stringify(result);
+}
+
+function parse(payload, schema) {
+  var result = {},
+      obj = {};
+
+  function append(obj, key, type, value) {
+    var types = {
+      String: function() {
+        obj[key] = value.sv;
+      },
+      Number: function() {
+        obj[key] = value.v;
+      },
+      Boolean: function() {
+        obj[key] = value.bv;
+      },
+      Buffer: function() {
+        obj[key] = Buffer.from(value.sv, 'base64');
+      },
+    };
+
+
+    if (Array.isArray(type)) {
+      var id = value.n.split('/')[1];
+
+      if (!obj[key]) {
+        obj[key] = [];
+      }
+
+      append(obj[key], id, type[0], value);
+    } else {
+      (types[type])();
+    }
+
+    if (obj[key] === undefined) {
+      throw new Error('JSON payload does not match ' + 
+        schema.name + ' definition');
+    }
+
+    return obj;
+  }
+
+  obj = JSON.parse(payload);
+
+  if (!Array.isArray(obj.e)) {
+    throw new Error('Invalid JSON payload');
+  }
+
+  for (var i = 0; i < obj.e.length; ++i) {
+    var key, type;
+
+    key = schema.resourceNameById(obj.e[i].n.split('/')[0]);
+
+    // skip resources not defined in schema.
+    if (!key) {
+      continue; 
+    }
+
+    type = schema.resources[key].type;
+
+    append(result, key, type, obj.e[i]);
+  }
+
+  return result;
+}
+
+exports.serialize = serializeToString;
+exports.parse = parse;

--- a/lib/services/object/server.js
+++ b/lib/services/object/server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 'use strict';

--- a/lib/services/object/server.js
+++ b/lib/services/object/server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
  *
  * This file is part of lwm2m-node-lib
  *
@@ -23,11 +23,12 @@
 
 'use strict';
 
-exports.server = require('./lwm2m-server');
-exports.client = require('./lwm2m-client');
+var Schema = require('./schema');
 
-var object = require('./services/object');
-exports.Schema = object.Schema; // constructor
-exports.schemas = object.schemas; // OMA LWM2M Objects
-
+module.exports = new Schema('LWM2M Server', {
+  serverId:     { type: Number, id: 0, required: true },
+  lifetime:     { type: Number, id: 1, required: true },
+  notifStoring: { type: Boolean, id: 6, required: true},
+  binding:      { type: String, id:7, required: true }
+});
 

--- a/test/unit/common/object-schema-test.js
+++ b/test/unit/common/object-schema-test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 'use strict';

--- a/test/unit/common/object-schema-test.js
+++ b/test/unit/common/object-schema-test.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ *
+ * This file is part of lwm2m-node-lib
+ *
+ * lwm2m-node-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * lwm2m-node-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with lwm2m-node-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+'use strict';
+
+var should = require('should'), // jshint ignore:line
+    Schema = require('../../../').Schema;
+
+describe('LWM2M Object Schema', function() {
+
+  describe('constructor', function() {
+    it('should throw when a resource definition is not correct', function() {
+      var def = {
+        a: { type: String, id: 0 },
+        b: { bad: 'value' }
+      };
+
+      function schema() { 
+        new Schema('test', def);
+      }
+      
+      schema.should.throw(TypeError);
+    });
+
+    it('should throw when presented with invalid resource type', function() {
+      var def = {
+        a: { type: String, id: 0 },
+        b: { type: RegExp, id: 1 }
+      };
+
+      function schema() { 
+        new Schema('test', def);
+      }
+      
+      schema.should.throw(TypeError);
+    });
+
+  });
+
+  describe('validate', function() {
+
+    it('should be ok when an object matches an schema', function() {
+      var def = {
+        a: { type: String, id: 0 },
+        b: { type: Number, id: 1 }
+      };
+
+      var schema = new Schema('test', def);
+
+      function validate() {
+        return schema.validate({ a: 'foo', b: 3 });
+      }
+      
+      validate.should.not.throw(TypeError);
+    });
+
+    it('should be ok when an object uses Object IDs as keys', function() {
+      var def = {
+        a: { type: String, id: 0 },
+        b: { type: Number, id: 1 }
+      };
+
+      var schema = new Schema('test', def);
+
+      function validate() {
+        return schema.validate({ 0: 'foo', 1: 3 });
+      }
+      
+      validate.should.not.throw(TypeError);
+    });
+
+    it('should throw when an object does not match schema', function() {
+      var def = {
+        a: { type: String, id: 0 },
+        b: { type: Number, id: 1 },
+        c: [{ type: Boolean, id: 2 }]
+      };
+
+      var schema = new Schema('test', def);
+
+      function validate() {
+        return schema.validate({ a: 'foo', b: false });
+      }
+      
+      validate.should.throw(TypeError);
+
+      function validate2() {
+        return schema.validate({ a: 'foo', c: [1,2,3] });
+      }
+      
+      validate2.should.throw(TypeError);
+    });
+
+    it('should throw when missing a required resource', function() {
+      var def = {
+        a: { type: String, id: 0 },
+        b: { type: Number, id: 1, required: true }
+      };
+
+      var schema = new Schema('test', def);
+
+      function validate() {
+        return schema.validate({ a: 'foo' });
+      }
+      
+      validate.should.throw(TypeError);
+    });
+  });
+});
+

--- a/test/unit/common/object-senml-test.js
+++ b/test/unit/common/object-senml-test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ * Copyright 2017 Telefonica Investigación y Desarrollo, S.A.U
  *
  * This file is part of lwm2m-node-lib
  *
@@ -19,6 +19,8 @@
  *
  * For those usages not covered by the GNU Affero General Public License
  * please contact with::[contacto@tid.es]
+ *
+ * Author: Alexandre Moreno <alex_moreno@tutk.com>
  */
 
 'use strict';

--- a/test/unit/common/object-senml-test.js
+++ b/test/unit/common/object-senml-test.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Alexandre Moreno <alex_moreno@tutk.com>
+ *
+ * This file is part of lwm2m-node-lib
+ *
+ * lwm2m-node-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * lwm2m-node-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with lwm2m-node-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+'use strict';
+
+var should = require('should'), // jshint ignore:line
+    senml = require('../../../lib/services/object/senml'),
+    deviceSchema = require('../../../lib/services/object/device');
+
+var object = { 
+  manufacturer: 'Open Mobile Alliance',
+  modelNumber: 'Lightweight M2M Client',
+  serialNumber: '345000123',
+  firmwareVer: '1.0',
+  powerSrcs: [ 1, 5 ],
+  srcVoltage: [ 3800, 5000 ],
+  srcCurrent: [ 125, 900 ],
+  batteryLevel: 100,
+  memoryFree: 15,
+  errorCode: [ 0 ],
+  currentTime: 1367491215,
+  utcOffset: '+02:00',
+  timeZone: 'U' 
+};
+
+var payload = '{"e":[' +
+  '{"n":"0","sv":"Open Mobile Alliance"},' +
+  '{"n":"1","sv":"Lightweight M2M Client"},' +
+  '{"n":"2","sv":"345000123"},' +
+  '{"n":"3","sv":"1.0"},' +
+  '{"n":"6/0","v":1},' +
+  '{"n":"6/1","v":5},' +
+  '{"n":"7/0","v":3800},' +
+  '{"n":"7/1","v":5000},' +
+  '{"n":"8/0","v":125},' +
+  '{"n":"8/1","v":900},' +
+  '{"n":"9","v":100},' +
+  '{"n":"10","v":15},' +
+  '{"n":"11/0","v":0},' +
+  '{"n":"13","v":1367491215},' +
+  '{"n":"14","sv":"+02:00"},' +
+  '{"n":"15","sv":"U"}]}';
+
+describe('De/serializing LWM2M Objects from/into JSON', function() {
+
+  describe('serialize', function() {
+    it('should return a valid payload', function() {
+      var dev = senml.serialize(object, deviceSchema);
+
+      dev.should.equal(payload);
+    });
+  });
+
+  describe('parse', function() {
+    it('should return an object', function() {
+      var dev = senml.parse(payload, deviceSchema);
+
+      dev.should.be.an.Object().and.not.empty();
+    });
+
+    it('should strictly return matching resources from schema', function() {
+      var dev = senml.parse(payload, deviceSchema),
+          keys = Object.keys(deviceSchema.resources);
+
+      Object.keys(dev).should.matchEach(function(it) { 
+        return it.should.be.oneOf(keys);
+      });
+    });
+  });
+
+});
+


### PR DESCRIPTION
Currently this library lacks support to stream `LWM2M Objects` as defined by OMA LWM2M Spec. This is a prerequisite PR that adds library support to transport LWM2M Object instances.

We add an LWM2M Object `Schema` constructor to:

* Specify Object _definitions_ with Resource names, IDs, type and whether is mandatory or not.
* Validate Object Instances and Resources

This PR adds also support to JSON de/serializer (application/vnd.oma.lwm2m+json media type).
Added too unit tests for all the new features.

Here is an example:

```js

var lwm2m = require('lwm2m-node-lib');
var Schema = lwm2m.Schema;

// this can be found in lwm2m.objects.security
var schema = new Schema('LWM2M Security', {
  uri:        { type: String, id: 0, required: true },
  serverId:   { type: Number, id: 10, required: true },
  bootstrap:  { type: Boolean, id: 1, required: true },
  clientCert: { type: Buffer, id: 3, required: true },
  secret:     { type: Buffer, id: 5, required: true },
  // etc.
});

// keys can be both named, from the schema, or directly resource IDs
var obj = {
  uri: 'coap://localhost:5683', // or 0 : 'coap://localhost:5683'
  bootstrap: false,
  serverId: 2,
  clientCert: fs.readFileSync('./cert.pem'),
  secret: fs.readFileSync('./key.pem')
};

// JSON
// senml library is not exported, since it is meant to be used by read/write APIs
try {
  var payload = senml.serialize(obj, schema);
  var obj2 = senml.parse(payload, schema);
  assert.deepEqual(obj, obj2);
catch (e) {
  // ...
}
```

New APIs for reading/writing objects are not part of this PR, and no API has been modified, other than exporting the Schema constructor and some LWM2M Object definitions.

A contrived example of how this could be used to read/write objects:
```js
var schema = require('./MySchema');
var options = { schema: schema };

// if no schema is passed in the options, return the unparsed payload to the user
read(ep, path, options, callback); 

options = { 
  schema: schema,
  writeFormat: 'application-vnd-oma-lwm2m/json' 
}

write(ep, path, obj, options, callback);
```
Any input is appreciated. The patch is purposely limited in functionality (and intrusiveness) to discuss further on the implementation details.