### PR TITLE
Set Device type from query parameter in registration url

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,4 @@
 - Set Nodejs 8 as minimum version in packages.json (effectively removing Nodev6 from supported versions)
+- Device type can now be taken from the uri query parameter type. e.g. with this url /rd?ep=endpoint&lt=300&b=U&type=Type
+ the device type will be Type if the type is defined in config.js. In this way, other lwm2m client implementations in
+ which the URI-Path is not configurable can use the Device type functionality.

--- a/config.js
+++ b/config.js
@@ -7,6 +7,12 @@ config.server = {
     lifetimeCheckInterval: 1000,        // Minimum interval between lifetime checks in ms
     udpWindow: 100,
     defaultType: 'Device',
+    types: [
+        {
+            name: 'OtherType',
+            url: '/OtherType'
+        }
+    ],
     logLevel: 'FATAL',
     ipProtocol: 'udp4',
     serverProtocol: 'udp4',

--- a/lib/services/server/registration.js
+++ b/lib/services/server/registration.js
@@ -26,6 +26,7 @@
 var async = require('async'),
     errors = require('../../errors'),
     logger = require('logops'),
+    registrationUtils = require('./utils/deviceRegistrationUtils'),
     config,
     registry,
     coapUtils = require('./../coapUtils'),
@@ -44,7 +45,7 @@ function endRegistration(req, res) {
             res.code = error.code;
             res.end(error.name);
         } else {
-            var root = (config.baseRoot) ? config.baseRoot + '/': '';
+            var root = (config.baseRoot) ? config.baseRoot + '/' : '';
 
             logger.debug(context, 'Registration request ended successfully');
             res.code = '2.01';
@@ -83,16 +84,7 @@ function storeDevice(queryParams, req, callback) {
     logger.debug(context, 'Storing the following device in the db:\n%s', JSON.stringify(device, null, 4));
 
     device.path = req.urlObj.pathname;
-
-    if (req.url.match(/^\/rd\/?.*/)) {
-        device.type = config.defaultType;
-    } else if (config.types) {
-        for (var i in config.types) {
-            if (req.url.indexOf(config.types[i].url) === 0) {
-                device.type = config.types[i].name;
-            }
-        }
-    }
+    device.type = registrationUtils.getDeviceTypeFromUrlRequest(req.urlObj, config);
 
     if (device.type) {
         logger.debug(context, 'Registered device [%s] with type [%s]', device.name, device.type);

--- a/lib/services/server/utils/deviceRegistrationUtils.js
+++ b/lib/services/server/utils/deviceRegistrationUtils.js
@@ -1,0 +1,42 @@
+'use strict';
+
+
+function getDeviceTypeFromUrlRequest(urlObj, config) {
+    if (urlObj.pathname === '/rd') {
+
+        if (urlObj.query.includes('&type=')) {
+            var type;
+
+            urlObj.query.split('&').forEach(
+                function (queryParam) {
+                    if (queryParam.includes('type='))
+                        type = queryParam.split('=')[1];
+                }
+            );
+
+            for (var i in config.types) {
+                if (type === config.types[i].name)
+                    return type;
+            }
+
+        }
+        else
+            return config.defaultType;
+
+    }
+
+    else if (config.types) {
+
+        for (var i in config.types) {
+
+            if (urlObj.pathname.includes(config.types[i].url)) {
+                return config.types[i].name;
+            }
+
+        }
+
+    }
+
+}
+
+exports.getDeviceTypeFromUrlRequest = getDeviceTypeFromUrlRequest;

--- a/lib/services/server/utils/deviceRegistrationUtils.js
+++ b/lib/services/server/utils/deviceRegistrationUtils.js
@@ -1,3 +1,27 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of lwm2m-node-lib
+ *
+ * lwm2m-node-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * lwm2m-node-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with lwm2m-node-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+
 'use strict';
 
 

--- a/lib/services/server/utils/deviceRegistrationUtils.js
+++ b/lib/services/server/utils/deviceRegistrationUtils.js
@@ -9,28 +9,31 @@ function getDeviceTypeFromUrlRequest(urlObj, config) {
 
             urlObj.query.split('&').forEach(
                 function (queryParam) {
-                    if (queryParam.includes('type='))
+                    if (queryParam.includes('type=')) {
                         type = queryParam.split('=')[1];
+                    }
                 }
             );
 
             for (var i in config.types) {
-                if (type === config.types[i].name)
+                if (type === config.types[i].name) {
                     return type;
+                }
             }
 
         }
-        else
+        else {
             return config.defaultType;
+        }
 
     }
 
     else if (config.types) {
 
-        for (var i in config.types) {
+        for (var j in config.types) {
 
-            if (urlObj.pathname.includes(config.types[i].url)) {
-                return config.types[i].name;
+            if (urlObj.pathname.includes(config.types[j].url)) {
+                return config.types[j].name;
             }
 
         }

--- a/test/unit/server/device-registration-utils-test.js
+++ b/test/unit/server/device-registration-utils-test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+var registrationUtils = require('../../../lib/services/server/utils/deviceRegistrationUtils'),
+    assert = require('assert');
+
+describe('Device registration utils ', function () {
+
+    describe('When device registers with /rd and no type in query params', function () {
+
+        var config = {
+            defaultType: 'defaultType'
+        };
+
+        var urlObj = {
+            pathname: '/rd',
+            query: 'ep=testEndpoint&lt=85671&lwm2m=1.0&b=U'
+        };
+
+        var actual = registrationUtils.getDeviceTypeFromUrlRequest(urlObj, config);
+
+        it('should return default type', function () {
+            assert.equal(actual, config.defaultType);
+        });
+    });
+
+    describe('When device registers with /service/rd', function () {
+
+        var urlObj = {
+            pathname: '/service/rd',
+            query: 'ep=testEndpoint&lt=85671&lwm2m=1.0&b=U'
+        };
+
+
+        it('if config.types include service should return service type', function () {
+            var config = {
+                defaultType: 'defaultType',
+                types: [{
+                    url: '/service',
+                    name: 'service'
+                }]
+            };
+            var actual = registrationUtils.getDeviceTypeFromUrlRequest(urlObj, config);
+
+            assert.equal(actual, 'service');
+        });
+
+        it('if config.types include service should return service type', function () {
+            var config = {
+                defaultType: 'defaultType',
+                types: []
+            };
+            var actual = registrationUtils.getDeviceTypeFromUrlRequest(urlObj, config);
+
+            assert.equal(actual, undefined);
+        });
+
+    });
+
+    describe('When device registers with /rd and type in query params', function () {
+
+        var urlObj = {
+            pathname: '/rd',
+            query: 'ep=testEndpoint&lt=85671&lwm2m=1.0&b=U&type=service'
+        };
+
+
+        it('if config.types include service should return service type', function () {
+            var config = {
+                defaultType: 'defaultType',
+                types: [{
+                    url: '/service',
+                    name: 'service'
+                }]
+            };
+            var actual = registrationUtils.getDeviceTypeFromUrlRequest(urlObj, config);
+
+            assert.equal(actual, 'service');
+        });
+
+        it('if config.types include service should return service type', function () {
+            var config = {
+                defaultType: 'defaultType',
+                types: []
+            };
+            var actual = registrationUtils.getDeviceTypeFromUrlRequest(urlObj, config);
+
+            assert.equal(actual, undefined);
+        });
+
+    });
+
+
+});

--- a/test/unit/server/device-registration-utils-test.js
+++ b/test/unit/server/device-registration-utils-test.js
@@ -1,3 +1,27 @@
+/*
+ * Copyright 2014 Telefonica Investigación y Desarrollo, S.A.U
+ *
+ * This file is part of lwm2m-node-lib
+ *
+ * lwm2m-node-lib is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * lwm2m-node-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with lwm2m-node-lib.
+ * If not, seehttp://www.gnu.org/licenses/.
+ *
+ * For those usages not covered by the GNU Affero General Public License
+ * please contact with::[contacto@tid.es]
+ */
+
+
 'use strict';
 
 var registrationUtils = require('../../../lib/services/server/utils/deviceRegistrationUtils'),


### PR DESCRIPTION
Hi,

following your code and the functionality of the services in lwm2m-iotagent, we found the device type functionality relies on the URI-Path prefix presented in the device registration process. 

With a registration url `/Type/rd?ep=endpoint&lt=300&b=U` the device type will be `Type` if the type is defined in config.js.

As far as I can read, this implementation does not comply with the standard specification of OMA LwM2M v1.0 [1][2]. 

> Registration is performed by sending a CoAP POST to the LwM2MServer URI/rd, with registration parameters passed as query string parameters as per Table 24 and Object and Object Instances included in the payload as specified in Section 5.3.1. The response includes Location-Path Options, which indicate the path to use for updating or deleting the registration. The LwM2MServer MUST return a location under the /rd path segment.

Following the standard recommendation, this PR allows the server to extract the device type from the query string parameters, more specifically from the `type` query parameter. 

With this url `/rd?ep=endpoint&lt=300&b=U&type=Type` the device type will be `Type` if the type is defined in config.js.

In this way, other lwm2m client implementations in which the URI-Path is not configurable can use the Device type functionality.

As you can see in the code, a new function returning the device type has been created in deviceRegistrationUtils. While device-registration-utils-test.js tests all the cases for this new function. The new functionality is optional and fully compatible with the previous code. The PR extends the number of third-party implementations that can use the lwm2m-node-lib server.

[1] http://www.openmobilealliance.org/release/LightweightM2M/V1_0-20170208-A/OMA-TS-LightweightM2M-V1_0-20170208-A.pdf
[2] https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/230