### PR TITLE
Set device type from query parameter in registration url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 .project
 .metadata
 npm-debug.log
+package-lock.json
 
 *~

--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,4 @@
 - Set Nodejs 8 as minimum version in packages.json (effectively removing Nodev6 from supported versions)
+- Device type can now be taken from the uri query parameter type. e.g. with this url /rd?ep=endpoint&lt=300&b=U&type=Type
+ the device type will be Type if the type is defined in config.js. In this way, other lwm2m client implementations in
+ which the URI-Path is not configurable can use the Device type functionality.

--- a/config.js
+++ b/config.js
@@ -7,6 +7,12 @@ config.server = {
     lifetimeCheckInterval: 1000,        // Minimum interval between lifetime checks in ms
     udpWindow: 100,
     defaultType: 'Device',
+    types: [
+        {
+            name: 'OtherType',
+            url: '/OtherType'
+        }
+    ],
     logLevel: 'FATAL',
     ipProtocol: 'udp4',
     serverProtocol: 'udp4',

--- a/lib/services/server/registration.js
+++ b/lib/services/server/registration.js
@@ -26,6 +26,7 @@
 var async = require('async'),
     errors = require('../../errors'),
     logger = require('logops'),
+    registrationUtils = require('./utils/deviceRegistrationUtils'),
     config,
     registry,
     coapUtils = require('./../coapUtils'),
@@ -44,7 +45,7 @@ function endRegistration(req, res) {
             res.code = error.code;
             res.end(error.name);
         } else {
-            var root = (config.baseRoot) ? config.baseRoot + '/': '';
+            var root = (config.baseRoot) ? config.baseRoot + '/' : '';
 
             logger.debug(context, 'Registration request ended successfully');
             res.code = '2.01';
@@ -83,16 +84,7 @@ function storeDevice(queryParams, req, callback) {
     logger.debug(context, 'Storing the following device in the db:\n%s', JSON.stringify(device, null, 4));
 
     device.path = req.urlObj.pathname;
-
-    if (req.url.match(/^\/rd\/?.*/)) {
-        device.type = config.defaultType;
-    } else if (config.types) {
-        for (var i in config.types) {
-            if (req.url.indexOf(config.types[i].url) === 0) {
-                device.type = config.types[i].name;
-            }
-        }
-    }
+    device.type = registrationUtils.getDeviceTypeFromUrlRequest(req.urlObj, config);
 
     if (device.type) {
         logger.debug(context, 'Registered device [%s] with type [%s]', device.name, device.type);

--- a/lib/services/server/utils/deviceRegistrationUtils.js
+++ b/lib/services/server/utils/deviceRegistrationUtils.js
@@ -26,10 +26,12 @@
 
 
 function getDeviceTypeFromUrlRequest(urlObj, config) {
+    var type;
+
     if (urlObj.pathname.startsWith('/rd')) {
 
         if (urlObj.query.includes('&type=')) {
-            var type;
+
 
             urlObj.query.split('&').forEach(
                 function (queryParam) {
@@ -54,12 +56,12 @@ function getDeviceTypeFromUrlRequest(urlObj, config) {
 
     else if (config.types) {
 
-        for (var j in config.types) {
+        type = urlObj.pathname.substr(0, urlObj.pathname.length - 3);
 
-            if (urlObj.pathname.includes(config.types[j].url)) {
+        for (var j in config.types) {
+            if (type === config.types[j].url) {
                 return config.types[j].name;
             }
-
         }
 
     }

--- a/lib/services/server/utils/deviceRegistrationUtils.js
+++ b/lib/services/server/utils/deviceRegistrationUtils.js
@@ -26,7 +26,7 @@
 
 
 function getDeviceTypeFromUrlRequest(urlObj, config) {
-    if (urlObj.pathname === '/rd') {
+    if (urlObj.pathname.startsWith('/rd')) {
 
         if (urlObj.query.includes('&type=')) {
             var type;

--- a/test/unit/server/device-registration-utils-test.js
+++ b/test/unit/server/device-registration-utils-test.js
@@ -113,5 +113,61 @@ describe('Device registration utils ', function () {
 
     });
 
+    describe('When device registers with type /rd/rd', function () {
+
+        var urlObj = {
+            pathname: '/rd/rd',
+            query: 'ep=testEndpoint&lt=85671&lwm2m=1.0&b=U'
+        };
+
+        it('should return default type', function () {
+            var config = {
+                defaultType: 'defaultType',
+                types: [
+                    {
+                        url: '/service',
+                        name: 'service'
+                    },
+                    {
+                        url: '/rd',
+                        name: 'rd'
+                    }
+                ]
+            };
+            var actual = registrationUtils.getDeviceTypeFromUrlRequest(urlObj, config);
+
+            assert.equal(actual, 'defaultType');
+        });
+
+    });
+
+    describe('When device registers with type /lightConfig/rd', function () {
+
+        var urlObj = {
+            pathname: '/lightConfig/rd',
+            query: 'ep=testEndpoint&lt=85671&lwm2m=1.0&b=U'
+        };
+
+        it('should return LightConfig type', function () {
+            var config = {
+                defaultType: 'defaultType',
+                types: [
+                    {
+                        url: '/light',
+                        name: 'Light'
+                    },
+                    {
+                        url: '/lightConfig',
+                        name: 'LightConfig'
+                    }
+                ]
+            };
+            var actual = registrationUtils.getDeviceTypeFromUrlRequest(urlObj, config);
+
+            assert.equal(actual, 'LightConfig');
+        });
+
+    });
+
 
 });


### PR DESCRIPTION
Hi,

the functionality introduced is described in #152 . Due to test errors in lightweightm2m-node-lib discovered in https://github.com/telefonicaid/lightweightm2m-iotagent/pull/210#discussion_r338207022 I have created more tests and adapted the functionality to ensure tests pass in both repositories. 

I hope it works this time :)